### PR TITLE
Cast macosx_deployment_target to string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ class build_ext(_build_ext):
     def _build_lib(self, lib_dir, commands):
         macosx_deployment_target = sysconfig.get_config_var("MACOSX_DEPLOYMENT_TARGET")
         if macosx_deployment_target:
-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = macosx_deployment_target
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = str(macosx_deployment_target)
 
         for command in commands:
             subprocess.check_call(command, cwd=lib_dir)


### PR DESCRIPTION
Related to #54

Big Sur has a deployment target of `11` as opposed to `10.16` or `11.0`. Therefore `sysconfig.get_config_var()` converts it to an int (https://github.com/python/cpython/blob/3.9/Lib/sysconfig.py#L461). However, setting `os.environ[]` requires a string so it's raising an exception (https://github.com/python/cpython/blob/3.9/Lib/os.py#L755-L756).

There seems to be a discussion and some disagreement within Python (https://bugs.python.org/issue42504) on if this should be forced to a string or not, but the conversation died at the beginning of December.

Even if they decide to make it a string again it'll take awhile before it's available so I think it may be best to add the casting.